### PR TITLE
Remove hardcoded Windows-only path for libctru

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@
 .SUFFIXES:
 #---------------------------------------------------------------------------------
 
-CTRULIB=c:\devkitpro\ctrulib\libctru
-
 ifeq ($(strip $(DEVKITARM)),)
 $(error "Please set DEVKITARM in your environment. export DEVKITARM=<path to>devkitARM")
 endif


### PR DESCRIPTION
ಠ_ಠ
