### PR TITLE
Wrapping and fast scrolling in rom menu

### DIFF
--- a/source/ui_rommenu.c
+++ b/source/ui_rommenu.c
@@ -181,7 +181,10 @@ void ROMMenu_ButtonPress(u32 btn)
 	else if (btn & KEY_UP) // up
 	{
 		menusel--;
-		if (menusel < 0) menusel = 0;
+		if (menusel < 0) {
+			menusel = nfiles - 2;
+			menuscroll = menusel-(MENU_MAX-1);
+		}
 		if (menusel < menuscroll) menuscroll = menusel;
 		
 		menudirty = 2;
@@ -189,7 +192,26 @@ void ROMMenu_ButtonPress(u32 btn)
 	else if (btn & KEY_DOWN) // down
 	{
 		menusel++;
-		if (menusel > nfiles-1) menusel = nfiles-1;
+		if (menusel > nfiles-1) {
+			menusel = 0;
+			menuscroll = menusel;
+		}
+		if (menusel-(MENU_MAX-1) > menuscroll) menuscroll = menusel-(MENU_MAX-1);
+		
+		menudirty = 2;
+	}
+	else if (btn & KEY_LEFT) // left
+	{
+		menusel -= 18;
+		if (menusel < 0) menusel = 0;
+		if (menusel < menuscroll) menuscroll = menusel;
+		
+		menudirty = 2;
+	}
+	else if (btn & KEY_RIGHT) // right
+	{
+		menusel += 18;
+		if (menusel > nfiles-1) menusel = nfiles - 1;
 		if (menusel-(MENU_MAX-1) > menuscroll) menuscroll = menusel-(MENU_MAX-1);
 		
 		menudirty = 2;


### PR DESCRIPTION
Added support for wrap-around scrolling and use of the left/right
buttons to navigate through a page of roms at a time. Useful for if you
have a lot of roms to get through.
